### PR TITLE
Ignore deps-*/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 deps/
 node_modules/
+deps-*/


### PR DESCRIPTION
This makes it easy to maintain several local deps configurations (e.g. by linking dependencies to local development repositories).